### PR TITLE
Show a warning when using the AWS or Google SDK to optimize it

### DIFF
--- a/src/Cli/IO.php
+++ b/src/Cli/IO.php
@@ -98,6 +98,11 @@ class IO
         ]);
     }
 
+    public static function warning(string $message): void
+    {
+        self::writeln(Styles::bold(Styles::bgYellow(' ! ')) . ' ' . Styles::yellow($message));
+    }
+
     public static function enableVerbose(): void
     {
         if (self::$verboseMode) return;

--- a/src/Commands/Deploy.php
+++ b/src/Commands/Deploy.php
@@ -59,14 +59,11 @@ class Deploy extends ApplicationCommand
         ]);
 
         // Analyze dependencies for optimization warnings
-        $dependencyAnalysis = DependencyAnalyzer::analyzeComposerDependencies();
-        if (!empty($dependencyAnalysis['warnings'])) {
+        $dependencyWarnings = DependencyAnalyzer::analyzeComposerDependencies();
+        if (!empty($dependencyWarnings)) {
             IO::writeln(['']);
-            foreach ($dependencyAnalysis['warnings'] as $warning) {
+            foreach ($dependencyWarnings as $warning) {
                 IO::writeln(Styles::yellow('⚠ ' . $warning));
-            }
-            foreach ($dependencyAnalysis['suggestions'] as $suggestion) {
-                IO::writeln(Styles::gray('  ' . $suggestion));
             }
             IO::writeln(['']);
         }

--- a/src/Commands/Deploy.php
+++ b/src/Commands/Deploy.php
@@ -15,6 +15,7 @@ use Bref\Cli\BrefCloudClient;
 use Bref\Cli\Cli\IO;
 use Bref\Cli\Cli\Styles;
 use Bref\Cli\Components\ServerlessFramework;
+use Bref\Cli\Helpers\DependencyAnalyzer;
 use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -56,6 +57,19 @@ class Deploy extends ApplicationCommand
         IO::writeln([
             sprintf("Deploying %s to environment %s", Styles::bold($appName), Styles::bold($environment)),
         ]);
+
+        // Analyze dependencies for optimization warnings
+        $dependencyAnalysis = DependencyAnalyzer::analyzeComposerDependencies();
+        if (!empty($dependencyAnalysis['warnings'])) {
+            IO::writeln(['']);
+            foreach ($dependencyAnalysis['warnings'] as $warning) {
+                IO::writeln(Styles::yellow('⚠ ' . $warning));
+            }
+            foreach ($dependencyAnalysis['suggestions'] as $suggestion) {
+                IO::writeln(Styles::gray('  ' . $suggestion));
+            }
+            IO::writeln(['']);
+        }
 
         IO::spin('creating deployment');
 

--- a/src/Commands/Deploy.php
+++ b/src/Commands/Deploy.php
@@ -58,14 +58,13 @@ class Deploy extends ApplicationCommand
             sprintf("Deploying %s to environment %s", Styles::bold($appName), Styles::bold($environment)),
         ]);
 
-        // Analyze dependencies for optimization warnings
         $dependencyWarnings = DependencyAnalyzer::analyzeComposerDependencies();
         if (!empty($dependencyWarnings)) {
-            IO::writeln(['']);
+            IO::writeln('');
             foreach ($dependencyWarnings as $warning) {
-                IO::writeln(Styles::yellow('⚠ ' . $warning));
+                IO::warning($warning);
             }
-            IO::writeln(['']);
+            IO::writeln('');
         }
 
         IO::spin('creating deployment');

--- a/src/Helpers/DependencyAnalyzer.php
+++ b/src/Helpers/DependencyAnalyzer.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Cli\Helpers;
+
+use Exception;
+use JsonException;
+
+class DependencyAnalyzer
+{
+    /**
+     * @return array{warnings: string[], suggestions: string[]}
+     */
+    public static function analyzeComposerDependencies(string $composerJsonPath = 'composer.json'): array
+    {
+        if (!file_exists($composerJsonPath)) {
+            return ['warnings' => [], 'suggestions' => []];
+        }
+
+        try {
+            $composerContent = file_get_contents($composerJsonPath);
+            if ($composerContent === false) {
+                return ['warnings' => [], 'suggestions' => []];
+            }
+
+            $composer = json_decode($composerContent, true, 512, JSON_THROW_ON_ERROR);
+            if (!is_array($composer)) {
+                return ['warnings' => [], 'suggestions' => []];
+            }
+
+            $warnings = [];
+            $suggestions = [];
+
+            // Check for AWS SDK
+            $require = $composer['require'] ?? [];
+            if (is_array($require) && isset($require['aws/aws-sdk-php'])) {
+                $isOptimized = self::isAwsSdkOptimized($composerJsonPath);
+                if (!$isOptimized) {
+                    $warnings[] = 'AWS SDK detected - this can significantly increase deployment size';
+                    $suggestions[] = 'Consider optimizing AWS SDK by including only required services: https://github.com/aws/aws-sdk-php/tree/master/src/Script/Composer';
+                }
+            }
+
+            // Check for Google SDK
+            if (is_array($require) && (isset($require['google/apiclient']) || isset($require['google/cloud']))) {
+                $isOptimized = self::isGoogleSdkOptimized($composerJsonPath);
+                if (!$isOptimized) {
+                    $warnings[] = 'Google SDK detected - this can significantly increase deployment size';
+                    $suggestions[] = 'Consider optimizing Google SDK by removing unused services: https://github.com/googleapis/google-api-php-client#cleaning-up-unused-services';
+                }
+            }
+
+            return ['warnings' => $warnings, 'suggestions' => $suggestions];
+
+        } catch (JsonException) {
+            return ['warnings' => [], 'suggestions' => []];
+        }
+    }
+
+    /**
+     * Check if AWS SDK is optimized by looking for custom scripts or exclusions
+     */
+    private static function isAwsSdkOptimized(string $composerJsonPath): bool
+    {
+        try {
+            $composerContent = file_get_contents($composerJsonPath);
+            if ($composerContent === false) {
+                return false;
+            }
+
+            $composer = json_decode($composerContent, true, 512, JSON_THROW_ON_ERROR);
+            if (!is_array($composer)) {
+                return false;
+            }
+
+            // Check for AWS SDK optimization script
+            $scripts = $composer['scripts'] ?? [];
+            if (is_array($scripts) && isset($scripts['pre-autoload-dump'])) {
+                $preAutoloadDump = (array) $scripts['pre-autoload-dump'];
+                foreach ($preAutoloadDump as $script) {
+                    if (is_string($script) && str_contains($script, 'aws-sdk-php') && str_contains($script, 'remove-unused-services')) {
+                        return true;
+                    }
+                }
+            }
+
+            // Check for custom AWS SDK optimizations in extra section
+            if (isset($composer['extra']['aws']['includes'])) {
+                return true;
+            }
+
+            return false;
+
+        } catch (Exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if Google SDK is optimized by looking for custom exclusions
+     */
+    private static function isGoogleSdkOptimized(string $composerJsonPath): bool
+    {
+        try {
+            $composerContent = file_get_contents($composerJsonPath);
+            if ($composerContent === false) {
+                return false;
+            }
+
+            $composer = json_decode($composerContent, true, 512, JSON_THROW_ON_ERROR);
+            if (!is_array($composer)) {
+                return false;
+            }
+
+            // Check for Google SDK optimization script
+            $scripts = $composer['scripts'] ?? [];
+            if (is_array($scripts) && isset($scripts['pre-autoload-dump'])) {
+                $preAutoloadDump = (array) $scripts['pre-autoload-dump'];
+                foreach ($preAutoloadDump as $script) {
+                    if (is_string($script) && str_contains($script, 'google') && str_contains($script, 'remove-unused-services')) {
+                        return true;
+                    }
+                }
+            }
+
+            // Check for custom Google SDK optimizations in extra section
+            if (isset($composer['extra']['google']['exclude_files'])) {
+                return true;
+            }
+
+            return false;
+
+        } catch (Exception) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The `bref deploy` CLI will now suggest optimizing your deployment size when using the AWS or Google SDK.

Thanks to a tweak in composer.json their size can be drastically reduced.

Link for AWS SDK: https://github.com/aws/aws-sdk-php/tree/master/src/Script/Composer
For Google SDK: https://github.com/googleapis/google-api-php-client#cleaning-up-unused-services

<img width="1652" height="580" alt="Screen-002988" src="https://github.com/user-attachments/assets/21e98c67-2c98-4b0b-88a8-2a0acafd9d09" />
